### PR TITLE
Use edge intensity as criteria for zooming

### DIFF
--- a/radiosim/jet.py
+++ b/radiosim/jet.py
@@ -85,13 +85,15 @@ def create_jet(grid, num_comps, train_type, scaling):
             x[i], y[i] = np.array(pol2cart(r, y_rotation)) + center
 
             # width of gaussian, empirical, sx > sy because rotation up to pi 'changes' this property - fixed to have consistency
-            sx[i], sy[i] = np.sort((
-                img_size
-                / comps
-                * r_factor
-                * np.sqrt(i + 1)
-                / np.random.uniform(4, 8, size=2)
-            ))[::-1]
+            sx[i], sy[i] = np.sort(
+                (
+                    img_size
+                    / comps
+                    * r_factor
+                    * np.sqrt(i + 1)
+                    / np.random.uniform(4, 8, size=2)
+                )
+            )[::-1]
 
             # rotation aligned with the jet angle, empirical
             rotation[i] = y_rotation + np.random.normal(0, np.pi / 18)
@@ -130,21 +132,33 @@ def create_jet(grid, num_comps, train_type, scaling):
         jet_comp = np.array(component_from_list(img_size, amp, x, y, sx, sy, rotation))
         jet_img = np.sum(jet_comp, axis=0)
 
-        # zoom on source to equalize size differences from z-rotation
-        jet_img, jet_comp, zoom_factor = zoom_on_source(jet_img, jet_comp)
-        x = img_size / 2 + (x - img_size / 2) * zoom_factor
-        y = img_size / 2 + (y - img_size / 2) * zoom_factor
-        sx *= zoom_factor
-        sy *= zoom_factor
+        # get values at the edge of the image
+        edge_list = [
+            jet_img[0, :-1],
+            jet_img[:-1, -1],
+            jet_img[-1, ::-1],
+            jet_img[-2:0:-1, 0],
+        ]
+        edges = np.concatenate(edge_list)
+        edge_threshold = 0.01
+        if edges.max() < edge_threshold:
+            # zoom on source to equalize size differences from z-rotation
+            jet_img, jet_comp, zoom_factor = zoom_on_source(
+                jet_img, jet_comp, max_amp=edge_threshold
+            )
+            x = img_size / 2 + (x - img_size / 2) * zoom_factor
+            y = img_size / 2 + (y - img_size / 2) * zoom_factor
+            sx *= zoom_factor
+            sy *= zoom_factor
 
-        # random zoom out for more variance
-        zoom_out_factor = np.random.uniform(1 / 2, 1)  # 1/8: pad eg. 128 -> 1024
-        pad_value = (1 / zoom_out_factor - 1) * img_size / 2
-        jet_img, jet_comp = zoom_out(jet_img, jet_comp, pad_value=pad_value)
-        x = img_size / 2 + (x - img_size / 2) * zoom_out_factor
-        y = img_size / 2 + (y - img_size / 2) * zoom_out_factor
-        sx *= zoom_out_factor
-        sy *= zoom_out_factor
+            # random zoom out for more variance
+            zoom_out_factor = np.random.uniform(1 / 2, 1)  # 1/8: pad eg. 128 -> 1024
+            pad_value = (1 / zoom_out_factor - 1) * img_size / 2
+            jet_img, jet_comp = zoom_out(jet_img, jet_comp, pad_value=pad_value)
+            x = img_size / 2 + (x - img_size / 2) * zoom_out_factor
+            y = img_size / 2 + (y - img_size / 2) * zoom_out_factor
+            sx *= zoom_out_factor
+            sy *= zoom_out_factor
 
         # normalisation
         if scaling == "normalize":


### PR DESCRIPTION
New `edge_threshold`. If the intensity on the edge is too high (>0.01), the zooming is skipped. Zooming in is not necessary, since the source is at the edge already and zooming out would lead to vertical or horizontal edge in the resulting image. 

A lower `edge_threshold` reduces that edge, but results in less zooming and thus less variability. A higher `noise_level` makes the edge less visible.