### PR TITLE
Fix mojave roll

### DIFF
--- a/radiosim/gauss.py
+++ b/radiosim/gauss.py
@@ -130,17 +130,13 @@ def skewed_gauss(
         return func
 
     vals = np.arange(size)
-    normal = norm.pdf(vals, loc=size / 2, scale=width).reshape(-1, 1)
+    normal = norm.pdf(vals, loc=y, scale=width).reshape(-1, 1)
     normal /= normal.max()
 
-    skew = skewfunc(vals, a=a, loc=size / 2, scale=length)
+    skew = skewfunc(vals, a=a, loc=x, scale=length)
 
     skew_gauss = normal * skew
     skew_gauss *= amp
     skew_gauss[np.isclose(skew_gauss, 0)] = 0
-
-    skew_gauss = np.roll(
-        skew_gauss, (y - int(size / 2), x - int(size / 2)), axis=(0, 1)
-    )
 
     return skew_gauss

--- a/radiosim/mojave.py
+++ b/radiosim/mojave.py
@@ -80,11 +80,7 @@ def gen_jet(
     ----------
     size : int
         length of the square image
-    x : float
-        x coordinate of the center
-    y : float
-        y coordinate of the center
-    amp : float
+    amplitude : float
         maximal amplitude of the distribution
     width : float
         width of the distribution (perpendicular to the skewed function)


### PR DESCRIPTION
Fixed oversight in generation of the skewed gaussians, leading to an unnecessary roll and thus a hard edge in some generated distributions.