### PR TITLE
Change convolve2d to fftconvolve

### DIFF
--- a/radiosim/utils.py
+++ b/radiosim/utils.py
@@ -266,7 +266,7 @@ def add_noise(image, noise_level):
             np.random.normal(mean, std, size=img_shape) * max_noise[:, None, None, None]
         )
         g_kernel = Gaussian2DKernel(kernel / 2).array[None, None, :]
-        return signal.convolve(noise, g_kernel, mode="same")
+        return signal.fftconvolve(noise, g_kernel, mode="same")
 
     def call_noise(kernels, strengths):
         """


### PR DESCRIPTION
This pull request includes a change to the `noise_small` function in the `radiosim/utils.py` file. The change improves the performance of the convolution operation by switching from `signal.convolve` to `signal.fftconvolve`.

* [`radiosim/utils.py`](diffhunk://#diff-62fc87bf216817fb694082364f15a776d9f7cc3f6cbb929592c8f02202a7b5f9L269-R269): Modified the `noise_small` function to use `signal.fftconvolve` instead of `signal.convolve` for better performance.